### PR TITLE
Update README.md - add instructions for generating a springified binstub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Add to your Gemfile:
 ``` ruby
 gem "spring-commands-rspec", group: :development
 ```
+
+If you're using spring binstubs, run `bundle exec spring binstub rspec` to generate `bin/rspec`.
+Then run `spring stop` to pick up the changes.


### PR DESCRIPTION
It took me a while to realize that I needed to stop spring in order to pickup my binstub changes. So I thought putting it in the README might be useful for future users. Let me know if you'd like me to reword anything.
