### PR TITLE
Generate binstub for rspec-core instead of rspec

### DIFF
--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -8,6 +8,10 @@ module Spring
       def exec_name
         "rspec"
       end
+
+      def gem_name
+        "rspec-core"
+      end
     end
 
     Spring.register_command "rspec", RSpec.new


### PR DESCRIPTION
This fixes a message about depreciation when trying to use the binstub:
`Bundler is using a binstub that was created for a different gem.
This is deprecated, in future versions you may need to bundle binstub rspec to work around a system/bundle conflict.`
