### PR TITLE
Insert rspec setup code into generated binstub

### DIFF
--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -12,6 +12,10 @@ module Spring
       def gem_name
         "rspec-core"
       end
+
+      def binstub_prelude
+        "RSpec.configuration.start_time = Time.now"
+      end
     end
 
     Spring.register_command "rspec", RSpec.new


### PR DESCRIPTION
- solves https://github.com/jonleighton/spring-commands-rspec/issues/18

This code relies on code in [this pull request](https://github.com/rails/spring/pull/329) and should NOT be merged until the other pull request is merged. At that time, the gemspec may also be updated to depend on the newer version of the spring gem.
