### PR TITLE
use #call to reset rspec start time setting before each run

### DIFF
--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -14,7 +14,7 @@ module Spring
       end
 
       def call
-        ::RSpec.configuration.start_time = Time.now
+        ::RSpec.configuration.start_time = Time.now if defined?(::RSpec.configuration)
         load Gem.bin_path(gem_name, exec_name)
       end
     end


### PR DESCRIPTION
- solves https://github.com/jonleighton/spring-commands-rspec/issues/18

This is an alternative to https://github.com/jonleighton/spring-commands-rspec/pull/20 per the discussion there.
