### PR TITLE
Do not hardcode Rails environment

### DIFF
--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -2,7 +2,7 @@ module Spring
   module Commands
     class RSpec
       def env(*)
-        "test"
+        ENV["RAILS_ENV"] || "test"
       end
 
       def exec_name
@@ -20,6 +20,6 @@ module Spring
     end
 
     Spring.register_command "rspec", RSpec.new
-    Spring::Commands::Rake.environment_matchers[/^spec($|:)/] = "test"
+    Spring::Commands::Rake.environment_matchers[/^spec($|:)/] = ENV["RAILS_ENV"] || "test"
   end
 end

--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -1,10 +1,6 @@
 module Spring
   module Commands
     class RSpec
-      def env(*)
-        ENV["RAILS_ENV"] || "test"
-      end
-
       def exec_name
         "rspec"
       end


### PR DESCRIPTION
Sometimes it's needed to use some different Rails env instead of default "test" so I suggest this little fix.
Also, I noticed that master branch doesn't work with rspec 2.14.1 (`Rspec.configuration` doesn't have `start_time=` method).
