### PR TITLE
Fix compatibility with RSpec 2.x

### DIFF
--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -14,7 +14,7 @@ module Spring
       end
 
       def call
-        ::RSpec.configuration.start_time = Time.now if defined?(::RSpec.configuration) && ::RSpec.configuration.respond_to?(:start_time=)
+        ::RSpec.configuration.start_time = Time.now if defined?(::RSpec.configuration.start_time)
         load Gem.bin_path(gem_name, exec_name)
       end
     end


### PR DESCRIPTION
The latest version breaks compatibility with older versions of RSpec.

::RSpec.configuration.start_time= was added in RSpec 3.0.0.

This method doesn't exist in RSpec 2.x, so the binstub fails with  `spring-commands-rspec-1.0.3/lib/spring/commands/rspec.rb:17:in`call': undefined method `start_time=' for #<RSpec::Core::Configuration:0x007f6d388dcf00> (NoMethodError)`

This PR checks if the start_time= method exists before calling it.

The issue Load time incorrect with Spring #18 doesn't occur with RSpec 2.x so no additional fix is necessary for that.

Other people are having this issue and are forking the repo to fix it. See https://github.com/lihanli/spring-commands-rspec
