### PR TITLE
Quick hack to fix spring usage under RubyMine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 This gem implements the `rspec` command for
 [Spring](https://github.com/jonleighton/spring).
 
+## Fork with hack for RubyMine
+
+This fork hacks in OSX RubyMine extension paths to load path so it doesn't
+fail to require dependencies if Spring server was started outside of RubyMine.
+
+Usage in Gemfile:
+
+``` ruby
+gem 'spring-commands-rspec', git: 'https://github.com/thewoolleyman/spring-commands-rspec.git'
+```
+
+
 ## Usage
 
 Add to your Gemfile:

--- a/lib/spring/commands/rspec.rb
+++ b/lib/spring/commands/rspec.rb
@@ -15,6 +15,10 @@ module Spring
 
       def call
         ::RSpec.configuration.start_time = Time.now if defined?(::RSpec.configuration.start_time)
+        # Hack in RubyMine extension paths to load path so it doesn't fail to require dependencies
+        # if Spring server was started outside of RubyMine.
+        $LOAD_PATH << '/Applications/RubyMine.app/Contents/rb/testing/patch/bdd/'
+        $LOAD_PATH << '/Applications/RubyMine.app/Contents/rb/testing/patch/common/'
         load Gem.bin_path(gem_name, exec_name)
       end
     end


### PR DESCRIPTION
Fixes failure when Spring was not started by RubyMine:

`cannot load such file -- teamcity/spec/runner/formatter/teamcity/formatter`

Just a quick hack, but shouldn't break anything even for non-RubyMine users, since it's just a load path addition.

Didn't put any more effort into it because I didn't see any recent activity on this repo, but I can clean up (e.g. conditionally only add if the paths exist) if desired to accept PR.  But I wanted to make a PR so other people with this issue can easily find [my fork with the fix](https://github.com/thewoolleyman/spring-commands-rspec) :).

Also added a separate README commit which can be thrown away before merging, I can make a clean PR if you want.

Thanks,
-- Chad
